### PR TITLE
Added non-locking flash functions

### DIFF
--- a/src/DueFlashStorage.cpp
+++ b/src/DueFlashStorage.cpp
@@ -88,3 +88,49 @@ boolean DueFlashStorage::write(uint32_t address, byte *data, uint32_t dataLength
   return true;
 }
 
+boolean DueFlashStorage::write_unlocked(uint32_t address, byte value) {
+  uint32_t retCode;
+  uint32_t byteLength = 1;  
+  byte *data;
+
+  // write data
+  retCode = flash_write((uint32_t)FLASH_START+address, &value, byteLength, 1);
+  //retCode = flash_write((uint32_t)FLASH_START, data, byteLength, 1);
+
+  if (retCode != FLASH_RC_OK) {
+    _FLASH_DEBUG("Flash write failed\n");
+    return false;
+  }
+
+  return true;
+}
+
+boolean DueFlashStorage::write_unlocked(uint32_t address, byte *data, uint32_t dataLength) {
+  uint32_t retCode;
+
+  if ((uint32_t)FLASH_START+address < IFLASH1_ADDR) {
+    _FLASH_DEBUG("Flash write address too low\n");
+    return false;
+  }
+
+  if ((uint32_t)FLASH_START+address >= (IFLASH1_ADDR + IFLASH1_SIZE)) {
+    _FLASH_DEBUG("Flash write address too high\n");
+    return false;
+  }
+
+  if (((uint32_t)FLASH_START+address & 3) != 0) {
+    _FLASH_DEBUG("Flash start address must be on four byte boundary\n");
+    return false;
+  }
+
+  // write data
+  retCode = flash_write((uint32_t)FLASH_START+address, data, dataLength, 1);
+
+  if (retCode != FLASH_RC_OK) {
+    _FLASH_DEBUG("Flash write failed\n");
+    return false;
+  }
+
+  return true;
+}
+

--- a/src/DueFlashStorage.h
+++ b/src/DueFlashStorage.h
@@ -47,6 +47,8 @@ public:
 	byte* readAddress(uint32_t address);
 	boolean write(uint32_t address, byte value);
 	boolean write(uint32_t address, byte *data, uint32_t dataLength);
+	boolean write_unlocked(uint32_t address, byte value);
+	boolean write_unlocked(uint32_t address, byte *data, uint32_t dataLength);
 };
 
 #endif


### PR DESCRIPTION
Was having trouble re-flashing an SAM3 board over the native connection when using the original code.  Added additional write functions that do not unlock and lock the flash.  Using the *_unlocked versions eliminates the need to use the erase line on the board (which was inconvenient).